### PR TITLE
Update csv_asset_loader.dart with additional delimiters

### DIFF
--- a/lib/src/csv_asset_loader.dart
+++ b/lib/src/csv_asset_loader.dart
@@ -59,8 +59,10 @@ class CSVParser {
           csvSettingsDetector:
               useAutodetect && fieldDelimiter == null && eol == null
                   ? FirstOccurrenceSettingsDetector(
+                      fieldDelimiters: [',', ';', '\t'],
+                      textDelimiters: ['"', "'", "”"],
+                      textEndDelimiters: ['"', "'", "”"],
                       eols: ['\r\n', '\n'],
-                      fieldDelimiters: [',', '\t'],
                     )
                   : null,
         );


### PR DESCRIPTION
Update csv_asset_loader.dart with additional field delimiters, text delimiters, text end delimiters. 

solves: https://github.com/aissat/easy_localization_loader/issues/42